### PR TITLE
Truncate current_tax_amount for system settings float precision

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -3,6 +3,7 @@
 
 
 import json
+import decimal
 
 import frappe
 from frappe import _, scrub
@@ -481,12 +482,18 @@ class calculate_taxes_and_totals:
 			].grand_total_for_current_item
 		elif tax.charge_type == "On Item Quantity":
 			current_tax_amount = tax_rate * item.qty
-
+			
+		current_tax_amount = float(self.truncate_tax_amount_(tax_amount=current_tax_amount))
+		
 		if not (self.doc.get("is_consolidated") or tax.get("dont_recompute_tax")):
 			self.set_item_wise_tax(item, tax, tax_rate, current_tax_amount)
 
 		return current_tax_amount
-
+		
+	def truncate_tax_amount_(self, tax_amount):
+		float_precision = frappe.db.get_single_value("System Settings", "float_precision")
+		return float(decimal.Decimal(tax_amount).quantize(decimal.Decimal((0, (1,), -int(float_precision))), rounding=decimal.ROUND_DOWN))
+		
 	def set_item_wise_tax(self, item, tax, tax_rate, current_tax_amount):
 		# store tax breakup for each item
 		key = item.item_code or item.item_name


### PR DESCRIPTION
I have a Invoice  with this items:
item1 price **3.31**
item2 price **0,83**
Taxes:
**On Net Total  vat 21% (rate 21)**

**Invoice Total  5,01**
the **item_wise_tax_detail**
'{"item1":[21.0,0.6950999999999999],"item2":[21.0,0.17429999999999998]}'
**the tax breakup:**
taxable amount     vat 21%
3,31                        0,70
0,83                        0,17

the total of invoice  should by 5.00  and not 5,01
I created this method and its only purpose is truncate  the **current_tax_amount**  with **System Settings** **float_presition** 
With this function the result y more exactly:
for float_presition 2 in System Settings
the **item_wise_tax_detail**
'{"item1":[21.0,0.69],"item2":[21.0,0.17]}'
**the tax breakup:**
taxable amount     vat 21%
3,31                        0,69
0,83                        0,17

Invoice total 5.00
